### PR TITLE
Page Header Text on Events Page

### DIFF
--- a/src/components/event/EventPage.tsx
+++ b/src/components/event/EventPage.tsx
@@ -110,8 +110,8 @@ export default EventPage;
 
 const getEventTitle = (eventType: 'active' | 'inactive') => {
   return eventType === 'active'
-    ? 'List of Active Events'
-    : 'List of Inactive Events';
+    ? 'Active Events'
+    : 'Inactive Events';
 };
 
 const getFetchFunction = (eventType: 'active' | 'inactive') => {


### PR DESCRIPTION
[Fix][Ivan] Changed the Page Header Text on Events Page: Removed 'List of' on both Active and Inactive Events