### PR TITLE
Redirect to event details

### DIFF
--- a/src/components/event/AddEventPage.tsx
+++ b/src/components/event/AddEventPage.tsx
@@ -78,11 +78,15 @@ const AddEventPage = () => {
     setFormData({ ...formData, date });
   };
 
+  const earlyBirdDateOnChange = (earlyBirdAccessDate: Dayjs | null) => {
+    setFormData({ ...formData, earlyBirdAccessDate });
+  };
+
   const addEventMutation = useMutation({
     mutationFn: async () => {
-      await addEvent(token, formData);
+      return await addEvent(token, formData);
     },
-    onSuccess: async () => {
+    onSuccess: async (newEvent) => {
       await queryClient.invalidateQueries({
         queryKey: ['events', 'active', { page: 1 }],
         exact: true,
@@ -97,6 +101,15 @@ const AddEventPage = () => {
         earlyBirdAccessDate: dayjs().add(1, 'day'),
       });
       toast.success('Added the event successfully');
+      if (newEvent && newEvent.id) {
+        router.push(`/event/view/${newEvent.id}`);
+      } else {
+        toast.error('Failed to retrieve the new event ID');
+      }
+    },
+    onError: (error) => {
+      console.error('Error in mutation:', error); // Log the error
+      toast.error(error.message);
     },
   });
 
@@ -178,7 +191,7 @@ const AddEventPage = () => {
               Boolean(formData.hasEarlyBirdAccess) && (
                 <DatePicker
                   value={formData.earlyBirdAccessDate}
-                  onChange={dateOnChange}
+                  onChange={earlyBirdDateOnChange}
                   label="Early Bird Access Date"
                   name="earlyBirdAccessDate"
                 />

--- a/src/components/event/EventPage.tsx
+++ b/src/components/event/EventPage.tsx
@@ -110,8 +110,8 @@ export default EventPage;
 
 const getEventTitle = (eventType: 'active' | 'inactive') => {
   return eventType === 'active'
-    ? 'List of Active Events'
-    : 'List of Inactive Events';
+    ? 'Active Events'
+    : 'Inactive Events';
 };
 
 const getFetchFunction = (eventType: 'active' | 'inactive') => {

--- a/src/utilities/fetch/event.ts
+++ b/src/utilities/fetch/event.ts
@@ -154,7 +154,6 @@ export const addEvent = async (token: string, event: AddEditEventDTO) => {
     throw new Error('Error in adding the event');
   }
   const data = await response.json();
-
   return data;
 };
 


### PR DESCRIPTION
[Ivan] Added newEvent.id in AddEventPage.tsx (addEventMutation) to redirect the page. The new event is reflected on the event/view/active page; however, after adding the event, it cannot be redirected to that specific event view page because newEvent.id cannot be retrieved (based on the toast). 